### PR TITLE
Add ability to turn off syntax highlighting

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -53,6 +53,7 @@ type swaggerConfig struct {
 	DeepLinking              bool
 	PersistAuthorization     bool
 	Oauth2DefaultClientID    string
+	SyntaxHighlight          bool
 }
 
 // Config stores hertzSwagger configuration variables.
@@ -81,6 +82,7 @@ func (config Config) toSwaggerConfig() swaggerConfig {
 		Title:                 config.Title,
 		PersistAuthorization:  config.PersistAuthorization,
 		Oauth2DefaultClientID: config.Oauth2DefaultClientID,
+		SyntaxHighlight:       config.SyntaxHighlight,
 	}
 }
 

--- a/swagger.go
+++ b/swagger.go
@@ -66,6 +66,7 @@ type Config struct {
 	DeepLinking              bool
 	PersistAuthorization     bool
 	Oauth2DefaultClientID    string
+	SyntaxHighlight          bool
 }
 
 func (config Config) toSwaggerConfig() swaggerConfig {
@@ -80,6 +81,13 @@ func (config Config) toSwaggerConfig() swaggerConfig {
 		Title:                 config.Title,
 		PersistAuthorization:  config.PersistAuthorization,
 		Oauth2DefaultClientID: config.Oauth2DefaultClientID,
+	}
+}
+
+// SyntaxHighlight true, false.
+func SyntaxHighlight(syntaxHighlight bool) func(*Config) {
+	return func(c *Config) {
+		c.SyntaxHighlight = syntaxHighlight
 	}
 }
 
@@ -314,6 +322,7 @@ window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
     url: "{{.URL}}",
+    syntaxHighlight: {{.SyntaxHighlight}},
     dom_id: '#swagger-ui',
     validatorUrl: null,
     oauth2RedirectUrl: {{.Oauth2RedirectURL}},

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -197,3 +197,10 @@ func TestOauth2DefaultClientID(t *testing.T) {
 	configFunc(&cfg)
 	assert.DeepEqual(t, "", cfg.Oauth2DefaultClientID)
 }
+
+func TestSyntaxHighlight(t *testing.T) {
+	var cfg Config
+	expected := true
+	SyntaxHighlight(expected)(&cfg)
+	assert.DeepEqual(t, expected, cfg.SyntaxHighlight)
+}


### PR DESCRIPTION
#### What type of PR is this?
feat: A new feature
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes

optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

Syntax highlighting is known to cause performance slowdowns for large responses. https://github.com/swagger-api/swagger-ui/issues/8260
I added a new function that turns off syntax highlighting.
Example usage:
```
	h.GET("/swagger/*any", swagger.WrapHandler(
		swaggerFiles.Handler,
		swagger.URL(fmt.Sprintf("%s/swagger/doc.json", url)),
		swagger.SyntaxHighlight(false),
	))
```

This PR is inspired and lifts some code from this PR https://github.com/swaggo/echo-swagger/pull/91
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
